### PR TITLE
Make JSON the default

### DIFF
--- a/geo/common/resources/collection.adoc
+++ b/geo/common/resources/collection.adoc
@@ -2,9 +2,10 @@
 
 == Overview
 
-The distribution of a geospatial dataset in an API is organized into one or more link:collections.adoc[collections of data]. 
+An OGC Collection resource is a JSON object that provides information about and access to a geospatial dataset through links to API endpoints and/or files online.
 
-Each OGC Collection resource provides information about and access to the data in the collection.
+It is often included in an API as one of several link:collections.adoc[collections of data]. 
+
 
 [[properties]]
 == Pre-defined properties
@@ -83,10 +84,6 @@ The token `{code}` is a placeholder for the authority’s code for the CRS. Some
 * http://www.opengis.net/def/crs/EPSG/0/3857 - Web Mercator (used in Web Mapping)
 * http://www.opengis.net/def/crs/EPSG/0/4258 - ETRS89 latitude, longitude
 
-== Representation: JSON 
-
-The JSON representation is the currently recommended representation that all APIs should support.
-
 === Example
 
 .Collection example (JSON)
@@ -144,13 +141,3 @@ ifndef::env-github[]
 include::collection.yaml[]
 ----
 endif::[]
-
-== Representation: HTML 
-
-Providing an HTML representation is recommended so that the resource can be displayed in a web browser and indexed by search engines.
-
-An HTML representation should include all information that is part of the JSON representation.
-
-=== Media type
-
-`text/html`

--- a/geo/common/resources/collections.adoc
+++ b/geo/common/resources/collections.adoc
@@ -7,7 +7,7 @@ The distribution of a geospatial dataset in an API is organized into one or more
 * By semantic type: For example, an airport dataset may be distributed with collections for buildings, taxiways, runways, etc.
 * By spatial clustering: For example, the same airport dataset may be distributed with a collection for each airport or country. 
 
-The OGC Collections resource provides information about and access to the data in each collection of the distribution.
+The OGC Collections JSON resource provides information about and access to the data in each collection of the distribution.
 
 [[properties]]
 == Pre-defined properties
@@ -51,13 +51,9 @@ This link relation type will not be registered with IANA. It will in the future 
 This link relation type will in the future supersede the `data` link relation type.
 !===
 
-== Representation: JSON 
-
-The JSON representation is the currently recommended representation that all APIs should support.
-
 === Examples
 
-.Collections example with a single collection (JSON)
+.Collections example with a single collection
 [%collapsible]
 =================
 [source,JSON]
@@ -244,12 +240,6 @@ ifndef::env-github[]
 include::collections.yaml[]
 ----
 endif::[]
-
-== Representation: HTML 
-
-Providing an HTML representation is recommended so that the resource can be displayed in a web browser and indexed by search engines.
-
-The HTML representation should include all information that is part of the JSON representation.
 
 === Media type
 

--- a/geo/common/schemas/bbox.adoc
+++ b/geo/common/schemas/bbox.adoc
@@ -4,7 +4,7 @@ Version: 1.0.1
 
 == Overview
 
-A bounding box describes a simple spatial extent of a resource, for example, a feature, a feature collection or a dataset. The extent is "simple" in that the bounding box does not describe the precise location and shape of the resource, but provides an axis-aligned approximation of the spatial extent that can be used as an initial test whether two resources are potentially intersecting each other.
+The bounding box JSON object describes a simple spatial extent of a resource. For OGC API's this could be a feature, a feature collection or a dataset, but it can be used in any JSON resource that wants to communicate its rough location. The extent is "simple" in that the bounding box does not describe the precise location and shape of the resource, but provides an axis-aligned approximation of the spatial extent that can be used as an initial test whether two resources are potentially intersecting each other.
 
 The bounding box is also useful when displaying a resource in a map to determine the initial map view.
 
@@ -29,10 +29,6 @@ For WGS 84 longitude/latitude the values are in most cases the sequence of minim
 
 If the vertical axis is included, the third and the sixth number are the bottom and the top of the 3-dimensional bounding box.
 
-== Representation: JSON 
-
-A bounding box is embedded as an array in JSON representations of OGC API resources.
-
 === Example
 
 .Axis-aligned minimum bounding box of the 48 contiguous states of the United States of America (JSON)
@@ -55,9 +51,9 @@ include::bbox.yaml[]
 ----
 endif::[]
 
-== Representation: Text 
+== Alternate Representation: Text 
 
-The text representation of a bounding box is based on the JSON representation and represents the array as comma-separated values.
+The text representation of a bounding box is based on the JSON representation and represents the array as comma-separated values. 
 
 === Example
 

--- a/geo/common/schemas/extent.adoc
+++ b/geo/common/schemas/extent.adoc
@@ -4,7 +4,7 @@ Version: 1.0.1
 
 == Overview
 
-This object provides information about the spatial and temporal extent of a resource. 
+This JSON object provides information about the spatial and temporal extent of a resource. 
 
 A typical resource type is a collection and the object describes the extent of all items in the collection. 
 
@@ -62,10 +62,6 @@ If no value is provided, the default reference system is the Gregorian calendar 
 !===
 
 Additional properties for other descriptions of the temporal extent may be added.
-
-== Representation: JSON 
-
-The extent is embedded as an object in JSON representations of OGC API resources.
 
 === Example
 

--- a/other/common/resources/conformance-declaration.adoc
+++ b/other/common/resources/conformance-declaration.adoc
@@ -4,7 +4,7 @@ Version: 1.0.1
 
 == Description
 
-An OGC Conformance Declaration lists the conformance classes from standards or community specifications, identified by a URI, that the API conforms to. 
+An OGC Conformance Declaration is a JSON object that lists the conformance classes from standards or community specifications, identified by a URI, that the API conforms to. 
 
 Clients may but are not required to use this information. This resource is intended to support "generic" clients that want to access multiple implementations of OGC API standards - and not "just" a specific API / server. For this purpose, the server can declare the conformance classes it implements and conforms to.
 
@@ -36,10 +36,6 @@ This link relation type will not be registered with IANA. It will in the future 
 
 This link relation type will in the future supersede the `conformance` link relation type.
 !===
-
-== Representation: JSON 
-
-The JSON representation is the currently recommended representation that all APIs should support.
 
 === Example
 
@@ -76,7 +72,7 @@ include::conformance-declaration.yaml[]
 ----
 endif::[]
 
-== Representation: HTML 
+== Alternate Representation: HTML 
 
 An HTML representation should include all information that is part of the JSON representation.
 

--- a/other/common/resources/landing-page.adoc
+++ b/other/common/resources/landing-page.adoc
@@ -4,7 +4,7 @@ Version: 1.0.1
 
 == Description
 
-The OGC API Landing Page provides links to important resources in the API. All other OGC API resources are sub-resources of this resource.
+The OGC API Landing Page provides links to important resources in the API, as a JSON object. All other OGC API resources are sub-resources of this resource.
 
 The landing page will typically also include essential metadata about the API, for example, a title and a description.
 
@@ -58,10 +58,6 @@ The following link relation types may be useful in links to an OGC API Landing P
 The link relation type is not yet registered with IANA. It is proposed in an Internet Draft https://datatracker.ietf.org/doc/html/draft-nottingham-json-home-06[Home Documents for HTTP APIs].
 !===
 
-== Representation: JSON 
-
-The JSON representation is the currently recommended representation that all APIs should support.
-
 === Example
 
 .Landing page example (JSON)
@@ -109,7 +105,7 @@ include::landing-page.yaml[]
 ----
 endif::[]
 
-== Representation: HTML 
+== Alternate Representation: HTML 
 
 Providing an HTML representation is recommended so that the resource can be displayed in a web browser and indexed by search engines.
 

--- a/other/common/schemas/instant.adoc
+++ b/other/common/schemas/instant.adoc
@@ -10,8 +10,6 @@ All timestamps include a timezone. The use of UTC ("Z") is recommended.
 
 This describes the initial range of instant values. This range may be extended in the future to support additional use cases. Clients processing instant values must be prepared to receive other values. Clients may ignore values that they do not understand.
 
-== Representation: JSON 
-
 An instant is embedded as a string in JSON representations of OGC API resources.
 
 === Examples
@@ -44,7 +42,7 @@ include::instant.yaml[]
 ----
 endif::[]
 
-== Representation: Text 
+== Alternate Representation: Text 
 
 The text representation is identical to the RFC 3339 string.
 

--- a/other/common/schemas/interval.adoc
+++ b/other/common/schemas/interval.adoc
@@ -10,9 +10,7 @@ Both start and end instants are included in the interval.
 
 Open ranges at the start or end are supported.
 
-== Representation: JSON 
-
-An interval is embedded as an array with two items (start, end) in JSON representations of OGC API resources.
+The interval is embedded as an array with two items (start, end) in JSON representations of OGC API resources.
 
 Open ranges at the start or end are represented by a `null` value for the start/end.
 
@@ -54,7 +52,7 @@ include::interval.yaml[]
 ----
 endif::[]
 
-== Representation: Text
+== Alternate Representation: Text
 
 The text representation of an interval values does not use the standard representation of an array, that is as comma-separated values. The text representation is based on ISO 8601 and the two instants are separated by a solidus ("/"). Open ranges at the start or end are represented using a double-dot (".."). An empty string ("") represents an unknown value for the start/end and may be used, too.
 

--- a/other/common/schemas/link.adoc
+++ b/other/common/schemas/link.adoc
@@ -4,7 +4,7 @@ Version: 1.0.1
 
 == Overview
 
-Web linking according to http://tools.ietf.org/rfc/rfc8288.txt[RFC 8288] is used to express relationships between resources.
+Web linking according to http://tools.ietf.org/rfc/rfc8288.txt[RFC 8288] is used to express relationships between resources. The JSON object representation of links described here is used consistently in OGC API's.
 
 [[properties]]
 == Pre-defined properties
@@ -25,10 +25,6 @@ The `anchor` attribute is currently not mentioned in OGC API Features.
 !===
 
 Additional link attributes may be added to the Link object.
-
-== Representation: JSON 
-
-Links are embedded as objects in JSON representations of OGC API resources.
 
 === Example
 


### PR DESCRIPTION
This PR upgrades JSON so it isn't just one 'representation', but makes it the default throughout.

It also tried to make things so it talked a bit less about an 'API', to open up 'static' possibilities.

It is currently a bit inconsistent on 'html'. In some cases I removed it, in others left it in and called it 'alternate'. Should get to a consistent approach.